### PR TITLE
fix an overflow error

### DIFF
--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -277,7 +277,7 @@ impl CPU {
 
     fn opcode_8xye(&mut self, x: usize, y: usize) -> ProgramCounter {
         self.registers[0x0f] = (self.registers[x] & 0b10000000) >> 7;
-        self.registers[x] *= 2;
+        self.registers[x] <<= 1;
 
         ProgramCounter::Next
     }


### PR DESCRIPTION
In some case the game can rely on this instruction doing an overflow. By only doing a multiplication rust can throw an error when an overflow occurs.
You can find this bug in the game BLINKY